### PR TITLE
#161994832 Fix html entities in article title from copy and paste

### DIFF
--- a/src/components/article/createArticle/createArticle.js
+++ b/src/components/article/createArticle/createArticle.js
@@ -215,8 +215,9 @@ export class CreateArticle extends Component {
   async finish() {
     const { publishArticle, hideResponse, history } = this.props;
     const {
-      title, body, description, tags, imageUrl, isPrivate, downloadable
+      body, description, tags, imageUrl, isPrivate, downloadable
     } = this.state;
+    const { title } = this.state.rawTextValue;
     const articleData = {
       title, body, description, tags, imageUrl, isPrivate, downloadable
     };

--- a/src/components/article/updateArticle/updateArticle.js
+++ b/src/components/article/updateArticle/updateArticle.js
@@ -12,7 +12,7 @@ import {
   hideCreateError,
   hideCreateResponse
 } from '../../../redux/actions/articles/articles';
-import { createArticleConstraint } from '../../../validators/constraints/article';
+import { updateArticleConstraint } from '../../../validators/constraints/article';
 import uploadArticleImage from '../../../services/cloudinary';
 import '../style.scss';
 import TitleInput from '../Editor/TitleInput';
@@ -37,6 +37,7 @@ export class UpdateArticle extends Component {
       tags: [],
       isPrivate: false,
       downloadable: true,
+      edited: false
     };
     this.publishHandler = this.publishHandler.bind(this);
     this.titleChangeHandler = this.titleChangeHandler.bind(this);
@@ -100,6 +101,7 @@ export class UpdateArticle extends Component {
       title
     };
     this.setState({
+      edited: true,
       rawTextValue
     });
   }
@@ -116,6 +118,7 @@ export class UpdateArticle extends Component {
       body: rawBody
     };
     this.setState({
+      edited: true,
       rawTextValue,
       description
     });
@@ -241,7 +244,7 @@ export class UpdateArticle extends Component {
 
   publishHandler() {
     const { rawTextValue } = this.state;
-    const errors = validate(rawTextValue, createArticleConstraint);
+    const errors = validate(rawTextValue, updateArticleConstraint);
     if (errors) {
       this.props.showError(errors);
     } else {
@@ -255,8 +258,9 @@ export class UpdateArticle extends Component {
     } = this.props;
     const { slug } = match.params;
     const {
-      title, body, description, tags, isPrivate, downloadable
+      body, description, tags, isPrivate, downloadable
     } = this.state;
+    const { title } = this.state.rawTextValue;
     const articleData = {
       title, body, description, tags, isPrivate, downloadable
     };
@@ -318,7 +322,7 @@ export class UpdateArticle extends Component {
               finish={this.finish}
             />
             <div className='container publish'>
-              <button className='publish__button' onClick={this.publishHandler} disabled={!this.state.rawTextValue.body}>Update and Publish</button>
+              <button className='publish__button' onClick={this.publishHandler} disabled={!this.state.edited}>Update and Publish</button>
             </div>
             <div className='container form'>
               <div className='columns'>

--- a/src/tests/components/article/updateArticle/updateArticle.test.js
+++ b/src/tests/components/article/updateArticle/updateArticle.test.js
@@ -142,6 +142,7 @@ describe('UpdateArticle Component', () => {
       title: 'Test title',
       body: '<p>Test body content<p>',
       description: 'Test body content',
+      edited: true
     });
     wrapper.find('.publish__button').simulate('click');
     expect(publishSpy).toHaveBeenCalled();
@@ -179,6 +180,7 @@ describe('UpdateArticle Component', () => {
       title: 'Test title',
       body: '<p>Test body content<p>',
       description: 'Test body content',
+      edited: true
     });
     const titleEvent = {
       target: {
@@ -221,6 +223,7 @@ describe('UpdateArticle Component', () => {
       title: 'Test title',
       body: '<p>Test body content<p>',
       description: 'Test body content',
+      edited: true
     });
     wrapper.instance().titleEditorChangeHandler('Test title');
     wrapper.instance().bodyEditorChangeHandler('Test body content');
@@ -253,6 +256,7 @@ describe('UpdateArticle Component', () => {
       title: 'Title',
       body: '<p>Start typing ...</p>',
       description: 'Test body content',
+      edited: true
     });
     wrapper.instance().titleFocusInHandler();
     wrapper.instance().bodyFocusInHandler();
@@ -285,6 +289,7 @@ describe('UpdateArticle Component', () => {
       title: '',
       body: '',
       description: '',
+      edited: true
     });
     wrapper.instance().titleFocusOutHandler();
     wrapper.instance().bodyFocusOutHandler();
@@ -323,7 +328,8 @@ describe('UpdateArticle Component', () => {
         label: 'Test',
         value: 'Test',
         __isNew__: true
-      }]
+      }],
+      edited: true
     });
     wrapper.find('.publish__button').simulate('click');
     wrapper.find('.action__finish').simulate('click');
@@ -365,7 +371,8 @@ describe('UpdateArticle Component', () => {
         label: 'Test',
         value: 'Test',
         __isNew__: true
-      }]
+      }],
+      edited: true
     });
     wrapper.find('.publish__button').simulate('click');
     wrapper.find('.action__cancel').simulate('click');
@@ -419,7 +426,8 @@ describe('UpdateArticle Component', () => {
         label: 'Test',
         value: 'Test',
         __isNew__: true
-      }]
+      }],
+      edited: true
     });
     wrapper.find('.publish__button').simulate('click');
     wrapper.instance().tagChangeHandler(newTags);
@@ -467,7 +475,8 @@ describe('UpdateArticle Component', () => {
       },
       title: 'Test title',
       body: '<p>Test body content<p>',
-      description: 'Test body content'
+      description: 'Test body content',
+      edited: true
     });
     wrapper.find('.publish__button').simulate('click');
     wrapper.instance().checkBoxHandler(isPrivate);

--- a/src/validators/constraints/article.js
+++ b/src/validators/constraints/article.js
@@ -1,5 +1,5 @@
 // eslint-disable-next-line import/prefer-default-export
-export const createArticleConstraint = {
+const createArticleConstraint = {
   title: {
     presence: true,
     length: {
@@ -23,3 +23,7 @@ export const createArticleConstraint = {
     }
   }
 };
+
+const updateArticleConstraint = { ...createArticleConstraint };
+updateArticleConstraint.body.presence = false;
+export { createArticleConstraint, updateArticleConstraint };


### PR DESCRIPTION
#### What does this PR do?
Fixes the issue caused by sending htmlentities from text copied and
   pasted into the title field to the server during create and update article
#### Description of Task to be completed?
- Fixes the issue caused by sending htmlentities as part of the title value
- Improve update article process by eliminating the need for the body field to be edited before `update and publish` button can come up.
- Return previously deleted `App.test.js` by this [PR](https://github.com/andela/odin-ah-frontend/pull/10)
#### How should this be manually tested?
1. Go to /article/new on the frontend app to create an article
2. Copy the title from this [medium post](https://medium.com/@sola.dav7/the-straw-that-almost-broke-my-camels-back-1cff2f126d53) 
3. Paste it in the title editor, fill in the body editor with text and publish the article.
4. Go to the homepage where the article is listed as part of the list of articles are displayed. You should see  " `  " quote rendered properly instead of the`&rsquo;s`
#### Any background context you want to provide?
#### What are the relevant pivotal tracker stories?
[#161994832](https://www.pivotaltracker.com/story/show/161994832)
#### Screenshots (if appropriate)
Screenshot of the bug in action.
![Bug capture](https://res.cloudinary.com/mentos/image/upload/v1542309763/Screen_Shot_2018-11-15_at_7.54.36_PM.png)

#### Questions: