### PR TITLE
#162008987 Fixes route issue

### DIFF
--- a/src/components/routes/Routes.js
+++ b/src/components/routes/Routes.js
@@ -24,6 +24,16 @@ const Routes = ({ location }) => (
     <Switch>
       <Route exact={true} path='/' component={LandingPageContainer}/>
       <Route exact={true} path='/home' component={Home}/>
+      <AuthRoute
+        location={location}
+        path="/article/new"
+        component={CreateArticle}
+      />
+      <AuthRoute
+        location={location}
+        path="/article/edit/:slug"
+        component={UpdateArticle}
+      />
       <Route path='/article/:slug' component={ReadArticle}/>
       <GuestRoute
         location={location}
@@ -59,16 +69,6 @@ const Routes = ({ location }) => (
         location={location}
         path="/dashboard"
         component={DashboardContainer}
-      />
-      <AuthRoute
-        location={location}
-        path="/article/new"
-        component={CreateArticle}
-      />
-      <AuthRoute
-        location={location}
-        path="/article/edit/:slug"
-        component={UpdateArticle}
       />
     </Switch>
     <Modal/>


### PR DESCRIPTION
#### What does this PR do?
This PR fixes the bug that displays 404 for `/article/new` because the `/article/{slug}` route precedes it. Therefore making it read `new` as a slug instead of a unique route
#### Description of Task to be completed?
- /article/new should not result in a 404
#### How should this be manually tested?
- Start the application using `npm start`
- Navigate to `localhost:3000/article/new`. You should no longer see a 404 error
#### Any background context you want to provide?
#### What are the relevant pivotal tracker stories?
[#162008987]()
#### Screenshots (if appropriate)
#### Questions: