### PR TITLE
#162192685 Fix avatar on comment

### DIFF
--- a/src/components/article/readArticle/index.jsx
+++ b/src/components/article/readArticle/index.jsx
@@ -112,7 +112,7 @@ export class ReadArticle extends Component {
               handleBookmark={this.handleBookmark}
               handleInteraction={this.handleInteraction}
             />
-            <CommentContainer user={article.author} slug={slug}/>
+            <CommentContainer slug={slug}/>
           </div>
         }
       </React.Fragment>

--- a/src/components/comment/CommentContainer.js
+++ b/src/components/comment/CommentContainer.js
@@ -100,7 +100,8 @@ export class CommentContainer extends Component {
     const {
       sendingComment, comments, user, isAuthenticated
     } = this.props;
-    const userImage = user.imageUrl || 'https://image.shutterstock.com/image-vector/male-default-placeholder-avatar-profile-450w-387516193.jpg';
+    const defaultImage = 'https://image.shutterstock.com/image-vector/male-default-placeholder-avatar-profile-450w-387516193.jpg';
+    const userImage = user && user.imageUrl ? user.imageUrl : defaultImage;
     return (
       <CommentBox
         onFocus={this.onFocus}
@@ -137,7 +138,8 @@ const mapStateToProps = state => ({
   refreshComments: state.comment.refreshComments,
   comments: state.comment.comments,
   errors: state.comment.errors,
-  isAuthenticated: state.login.isAuthenticated
+  isAuthenticated: state.login.isAuthenticated,
+  user: state.login.user
 });
 
 const mapDispatchToProps = {

--- a/src/tests/reducers/bookmark.test.js
+++ b/src/tests/reducers/bookmark.test.js
@@ -34,7 +34,7 @@ it('update state with fetched bookmarks', () => {
 
   };
   const newState = reducer(initialState, successAction);
- expect(newState.loadingArticles).toBe(false);
+  expect(newState.loadingArticles).toBe(false);
 });
 
 it('fetch articles from store', () => {
@@ -59,4 +59,3 @@ it('should not update state', () => {
   const newState = reducer(initialState, action);
   expect(newState).toEqual(initialState);
 });
-


### PR DESCRIPTION
#### What does this PR do?
- Fixes the bug where avatar on comment box shows the image of the article's author
  instead of that of the logged in user
#### Description of Task to be completed?
- Avatar beside comment input should be the avatar of the logged in user
#### How should this be manually tested?
- Start the application using npm start
- Go to to [localhost:3000](http://localhost:3000)
- Login with an existing account
- On the list of articles section, click on any article of your choice
- `http://localhost:3000/article/{article-slug}`
- Scroll down to see the comment input filed the avatar beside the input field should be your avatar as a logged in user
#### Any background context you want to provide?
#### What are the relevant pivotal tracker stories?
[#162192685](https://www.pivotaltracker.com/story/show/162192685)
#### Screenshots (if appropriate)
<img width="1440" alt="screen shot 2018-11-26 at 6 19 38 pm" src="https://user-images.githubusercontent.com/9039613/49031560-9321cb80-f1aa-11e8-8967-2a95497895ab.png">
<img width="1440" alt="screen shot 2018-11-26 at 6 19 46 pm" src="https://user-images.githubusercontent.com/9039613/49031580-a3d24180-f1aa-11e8-83fc-d3f73bfab09e.png">
#### Questions: